### PR TITLE
Fix garbled FBBS2.DOC file

### DIFF
--- a/modern/FBBS2.DOC
+++ b/modern/FBBS2.DOC
@@ -3,59 +3,60 @@
 
             Purpose
             -------
-              FBBÓ  standó  foò FORTÈ Bulletin-Boarä System¬   anä ió  á 
-            publiã  domaiî  tree-structureä  systeí  modeleä  afteò  thå 
-            Communi-treå  system®   Thå purposå iî placinç thió codå  iî 
-            thå publiã domaiî ió NOÔ tï providå á general-purposå do-alì 
-            BBÓ foò freå foò everyonå foò everù computer¬  buô ratheò tï 
-            providå á basiã systeí witè thå capabilitù tï bå expandeä iî 
-            almosô anù direction®   É wilì trù tï answeò questions¬  buô 
-            otheò thaî that¬  É caî offeò littlå oò nï freå supporô  foò 
-            thió system.
+              FBBS  stands  for FORTH Bulletin-Board System,   and is  a 
+            public  domain  tree-structured  system  modeled  after  the 
+            Communi-tree  system.   The purpose in placing this code  in 
+            the public domain is NOT to provide a general-purpose do-all 
+            BBS for free for everyone for every computer,  but rather to 
+            provide a basic system with the capability to be expanded in 
+            almost any direction.   I will try to answer questions,  but 
+            other than that,  I can offer little or no free support  for 
+            this system.
 
-              Tï  thoså whï wisè tï alteò thió systeí anä selì it¬  feeì 
-            freå tï dï so®  Iæ yoõ makå á loô oæ moneù anä feeì á littlå 
+              To  those who wish to alter this system and sell it,  feel 
+            free to do so.  If you make a lot of money and feel a little 
             guilty, feel free also to send me some royalties.
 
 
             General
             -------
-              Iæ yoõ nï littlå oò nothinç abouô tree-structureä BBS's¬ É 
-            stronglù adviså thaô yoõ spenä aî houò oò twï oî onå oæ  thå 
-            communitreå boardó (theù arå listeä iî Thå Computeò Shopper© 
-            tï  geô á feeì foò whaô ió goinç on®   Thå basiã premiså  ió 
-            thaô  eacè  messagå  iî thå treå ió appendeä tï  somå  otheò 
-            messagå  (itó parent©  anä may¬  iî turn¬  havå onå oò  morå 
-            messageó  appendeä  tï iô (itó  sub-messages)®   Theså  sub-
-            messageó  caî havå therå owî sub-messageó anä  sï  on®   Thå 
-            top-mosô  messagå  iî  thå treå woulä normallù havå  aó  itó 
-            submessageó  alì thå currenô majoò topicó iî thå tree®  Eacè 
-            oæ  theså  topicó coulä havå á lisô oæ commentó  abouô  thaô 
-            topic¬ anä thå commentó coulä havå comments¬ etc® etc.
+              If you no little or nothing about tree-structured BBS's, I 
+            strongly advise that you spend an hour or two on one of  the 
+            communitree boards (they are listed in The Computer Shopper) 
+            to  get a feel for what is going on.   The basic premise  is 
+            that  each  message  in the tree is appended to  some  other 
+            message  (its parent)  and may,  in turn,  have one or  more 
+            messages  appended  to it (its  sub-messages).   These  sub-
+            messages  can have there own sub-messages and  so  on.   The 
+            top-most  message  in  the tree would normally have  as  its 
+            submessages  all the current major topics in the tree.  Each 
+            of  these  topics could have a list of comments  about  that 
+            topic, and the comments could have comments, etc. etc.
 
-              Therå  ió onå uniquå messagå iî thå Tree¬  anä thaô ió  aô 
-            thå toğ oæ thå tree®   Thió messagå ió uniquå iî thaô iô haó 
-            nï parenô  (i.e® iô waó noô addeä tï anotheò message)®  Wheî 
-            thå  Treå ió firsô broughô up¬   thå routinå  ENTER-TOĞ  in-
-            itializeó thå systeí  anä allowó yoõ tï enteò thió  message®  
-            Alì  otheò messageó iî thå systeí arå addeä tï thió oò  somå 
-            otheò messagå usinç thå ADDTÏ <msg-name¾ command.
+              There  is one unique message in the Tree,  and that is  at 
+            the top of the tree.   This message is unique in that it has 
+            no parent  (i.e. it was not added to another message).  When 
+            the  Tree is first brought up,   the routine  ENTER-TOP  in-
+            itializes the system  and allows you to enter this  message.  
+            All  other messages in the system are added to this or  some 
+            other message using the ADDTO <msg-name> command.
 
 
-              Thå  commandó  (oò fortè lexicons© iî thió systeí  maù  bå 
-            spliô intï therå groups:
+              The  commands  (or forth lexicons) in this system  may  be 
+            split into there groups:
 
-                 1© Useò commands
+                 1) User commands
 
-                 2© Sysoğ commands
+                 2) Sysop commands
 
-                 3© Internaì commands.
+                 3) Internal commands.
 
-              Thå normaì useò woulä uså onlù thoså commandó foò reading¬ 
-            indexing¬  anä findinç messages®  Thå Sysoğ commandó includå 
-            thoså foò messagå removal¬  restructurinç thå tree¬  anä foò 
-            disë compaction®  Tï perforí theså commands¬  á largå seô oæ 
-            internaì commandó arå used¬  whicè neitheò thå sysoğ noò thå Š
+              The normal user would use only those commands for reading, 
+            indexing,  and finding messages.  The Sysop commands include 
+            those for message removal,  restructuring the tree,  and for 
+            disk compaction.  To perform these commands,  a large set of 
+            internal commands are used,  which neither the sysop nor the 
+
 
 
 
@@ -66,61 +67,62 @@
              Documentation for FBBS-2.0  ** 1/26/85  **  page 2
 
 
-            useò  neeä bå concerneä about®   Programmeró caî builä  morå 
-            useò  and/oò  sysoğ  functionó bù combininç  theså  internaì 
+            user  need be concerned about.   Programmers can build  more 
+            user  and/or  sysop  functions by combining  these  internal 
             commands.
 
-              Unlikå FBBS-1.0¬  nothinç aó systeí dependenô aó  limitinç 
-            whicè functionó caî bå executeä haó beeî implemented®  This¬ 
-            aó  welì aó sucè thingó aó modeí interface¬  arå lefô tï thå 
-            enä user.
+              Unlike FBBS-1.0,  nothing as system dependent as  limiting 
+            which functions can be executed has been implemented.  This, 
+            as  well as such things as modem interface,  are left to the 
+            end user.
 
 
-            Useò commands:
+            User commands:
             -------------
-              Theså  arå fe÷ iî numbeò anä general-purposå iî naturå  tï 
-            makå usinç thå boarä aó simplå aó possible:
+              These  are few in number and general-purpose in nature  to 
+            make using the board as simple as possible:
 
 
-            REAÄ <msg-name>  [date]
+            READ <msg-name>  [date]
             -----------------------
-               Thió  ió thå mosô commoî function¬  anä ió  ratheò  self-
-            explanatory® Á headinç ió printed¬  thå bodù oæ thå message¬ 
-            anä á lisô oæ anù submessages®   Thå outpuô maù bå pauseä bù 
-            hittinç anù key¬ oò terminateä bù hittinç K.
-              Iæ á datå ió supplied¬   onlù submessageó oî oò afteò thaô 
-            datå will be listed.
+               This  is the most common function,  and is  rather  self-
+            explanatory. A heading is printed,  the body of the message, 
+            and a list of any submessages.   The output may be paused by 
+            hitting any key, or terminated by hitting K.
+              If a date is supplied,   only submessages on or after that 
+            date will be listed.
 
 
-            BROWSÅ <msg-name> [date]
+            BROWSE <msg-name> [date]
             ------------------------
-              Thió ió jusô likå read¬ excepô thaô onlù thå firsô linå oæ 
-            thå messagå ió printed.
+              This is just like read, except that only the first line of 
+            the message is printed.
 
-            ADDTÏ <msg-name>
+            ADDTO <msg-name>
             ----------------
-              Thió  functioî ió foò addinç á sub-messagå tï aî  existinç 
-            message®   Iæ  thå directorù oò thå disë ió full¬  aî  erroò 
-            messagå wilì result®   Yoõ wilì bå askeä tï givå thå messagå 
-            á name¬   whicè maù bå uğ tï 3° characteró iî lengtè (longeò 
-            nameó wilì bå truncated)®   Thå namå maù noô contaiî spaces®    
-            Afteò  enterinç  thå name¬   alì lineó typeä iî wilì  becomå 
-            parô  oæ thå messagå untiì aî emptù linå  ió  entered®   Thå 
-            onlù  editinç provideä ió back-space®   Iæ yoõ wisè tï imbeä 
-            blanë lineó iî youò message¬  puô á spacå iî thå linå beforå 
-            hittinç  <cr¾  again®   Therå ió nï  limitatioî  oî  messagå 
-            lengtè iî thió systeí otheò thaî disë capacity.
-              Afteò enterinç aî emptù line¬  yoõ arå bacë iî thå regulaò 
+              This  function is for adding a sub-message to an  existing 
+            message.   If  the directory or the disk is full,  an  error 
+            message will result.   You will be asked to give the message 
+            a name,   which may be up to 30 characters in length (longer 
+            names will be truncated).   The name may not contain spaces.    
+            After  entering  the name,   all lines typed in will  become 
+            part  of the message until an empty line  is  entered.   The 
+            only  editing provided is back-space.   If you wish to imbed 
+            blank lines in your message,  put a space in the line before 
+            hitting  <cr>  again.   There is no  limitation  on  message 
+            length in this system other than disk capacity.
+              After entering an empty line,  you are back in the regular 
             mode.
 
 
-            INDEØ <msg-name>  [date]
+            INDEX <msg-name>  [date]
             ------------------------
-              Thió  functioî provideó á methoä oæ viewinç thå  structurå 
-            oæ  thå  treå belo÷ á certaiî message®   INDEØ FBBÓ   (wherå 
-            FBBÓ  ió  thå  toğ messagå iî thå tree©   wilì  displaù  thå 
-            structurå  oæ  thå entirå tree®   Eacè successivå  leveì  oæ 
-            commentó ió indenteä ² spaceó froí itó parent.Š
+              This  function provides a method of viewing the  structure 
+            of  the  tree below a certain message.   INDEX FBBS   (where 
+            FBBS  is  the  top message in the tree)   will  display  the 
+            structure  of  the entire tree.   Each successive  level  of 
+            comments is indented 2 spaces from its parent.
+
 
 
 
@@ -131,61 +133,62 @@
              Documentation for FBBS-2.0  ** 1/26/85  **  page 3
 
 
-              Iæ  á datå ió supplied¬   onlù messageó aoî oò afteò  thaô 
+              If  a date is supplied,   only messages aon or after  that 
             date will be listed.
 
 
             HELP
             ----
-              Thió jusô printó "trù REAÄ HELP¢  HELĞ ió á sysop-provideä 
-            messagå thaô maù contaiî alì oò parô oæ thió document® 
+              This just prints "try READ HELP"  HELP is a sysop-provided 
+            message that may contain all or part of this document. 
 
 
-            Sysoğ Commands
+            Sysop Commands
             --------------
-              Again¬  theså arå noô toï complicateä oò numerous¬ anä maù 
-            bå extendeä aó needed® É calì theí sysoğ commandó becauså iô 
+              Again,  these are not too complicated or numerous, and may 
+            be extended as needed. I call them sysop commands because it 
             may not be desired to give the users this much power.
 
 
             START
             -----
-              Wheî yoõ starô uğ thió system¬  thió commanä ió needeä  tï 
-            loaä á fe÷ variableó froí disk
+              When you start up this system,  this command is needed  to 
+            load a few variables from disk
 
-            REMOVÅ  <msg-name>
+            REMOVE  <msg-name>
             ------------------
-              Self-explanatory®    Botè  <msg-name¾   anä  anù  messageó 
-            appendeä  tï iô arå removed¬   anä thå associateä  directorù 
-            spacå (buô noô disë space© ió reclaimed®  Á trağ ió provideä 
-            tï prevenô removinç thå toğ oæ thå tree.
+              Self-explanatory.    Both  <msg-name>   and  any  messages 
+            appended  to it are removed,   and the associated  directory 
+            space (but not disk space) is reclaimed.  A trap is provided 
+            to prevent removing the top of the tree.
 
             CRUNCH
             ------
-              Thió commanä reclaimó anù disë spacå freeä viá REMOVE®  Iô 
-            ió slow¬  anä shoulä noô bå useä wheî noô needed®  Á staò ió 
-            printeä aó eacè messagå ió crunched.
+              This command reclaims any disk space freed via REMOVE.  It 
+            is slow,  and should not be used when not needed.  A star is 
+            printed as each message is crunched.
 
 
-            MOVÅ <msg-name¾ TÏ <msg-name>
+            MOVE <msg-name> TO <msg-name>
             -----------------------------
-              Thió  commanä allowó á messagå tï bå reassigneä tï anotheò 
-            parent¬   thuó  allowinç  yoõ tï movå á messagå tï   á  morå 
-            appropriatå  sectioî oæ thå treå iæ required®   Alì  submes-
-            sageó appendeä tï thå messagå arå moveä also®   Á commoî uså 
-            woulä bå tï movå á messagå tï á parenô calleä GOING..® prioò 
-            tï removinç iô tï givå useró somå warning.
+              This  command allows a message to be reassigned to another 
+            parent,   thus  allowing  you to move a message to   a  more 
+            appropriate  section of the tree if required.   All  submes-
+            sages appended to the message are moved also.   A common use 
+            would be to move a message to a parent called GOING... prior 
+            to removing it to give users some warning.
 
             ENTER-TOP
             ---------
-              Thió commanä ió dangerous¬ aó iô wilì wipå thå treå clean®  
-            Iô ió tï bå useä onlù tï enteò thå firsô messagå iî thå treå 
-            (iô ió á littlå difficulô tï uså ADDTÏ wheî therå ió nothinç 
-            tï addto).
+              This command is dangerous, as it will wipe the tree clean.  
+            It is to be used only to enter the first message in the tree 
+            (it is a little difficult to use ADDTO when there is nothing 
+            to addto).
 
-            RE-ENTEÒ <msg-name>
+            RE-ENTER <msg-name>
             -------------------
-              Normally¬  iæ yoõ enteò á messagå incorrectly¬ anä wisè tï Š
+              Normally,  if you enter a message incorrectly, and wish to 
+
 
 
 
@@ -196,61 +199,62 @@
              Documentation for FBBS-2.0  ** 1/26/85  **  page 4
 
 
-            changå it¬   yoõ woulä uså REMOVÅ anä ADDTO®  Iæ thå messagå 
-            iî questioî haä submessages¬   theù woulä bå lost®  RE-ENTEÒ 
-            allowó yoõ tï enteò ne÷ texô foò aî exitinç messagå  withouô 
-            loosinç  thå submessages®   Thió ió particularlù usefuì  foò 
-            changinç thå texô aô thå toğ oæ thå tree.
+            change it,   you would use REMOVE and ADDTO.  If the message 
+            in question had submessages,   they would be lost.  RE-ENTER 
+            allows you to enter new text for an exiting message  without 
+            loosing  the submessages.   This is particularly useful  for 
+            changing the text at the top of the tree.
 
             Internals:
             ----------
-              Uså  thå  commentó iî thå sourcå codå aó  á  primarù  ref-
-            erence¬  aó  É maù stilì makå somå changes®   É wilì trù  tï 
-            highlighô á fe÷ thingó herå thaô seeí á littlå obtuse.
+              Use  the  comments in the source code as  a  primary  ref-
+            erence,  as  I may still make some changes.   I will try  to 
+            highlight a few things here that seem a little obtuse.
 
 
-            #BLOCKS¬ DIR¬ #DIÒ anä TREE
+            #BLOCKS, DIR, #DIR and TREE
             ---------------------------
-              Theså  constantó  yoõ wilì likelù wisè tï change®   Aó  iô 
-            stands¬   botè thå sourcå codå anä thå treå datá arå iî  thå 
-            samå filå tï makå developmenô easier®   Mosô useró wilì wanô 
-            tï  uså á workinç filå aó largå aó possible¬  generallù  thå 
-            sizå oæ onå floppù disë oî á floppù system®   Changå #BLOCKÓ 
-            tï  thå  capacitù oæ thaô filå  (oò tï thå capacitù oæ  youò 
-            drivå systeí iæ yoõ arå usinç direcô disk-i/o)®  Iæ yoõ wanô 
-            tï  keeğ thå sourcå oî line¬   seô  DIÒ tï 40¬  leavinç  thå 
-            firsô 4° blockó oæ thå filå freå tï holä thå  code®   Other-
-            wise¬  seô DIÒ tï ° anä bå careful.
+              These  constants  you will likely wish to change.   As  it 
+            stands,   both the source code and the tree data are in  the 
+            same file to make development easier.   Most users will want 
+            to  use a working file as large as possible,  generally  the 
+            size of one floppy disk on a floppy system.   Change #BLOCKS 
+            to  the  capacity of that file  (or to the capacity of  your 
+            drive system if you are using direct disk-i/o).  If you want 
+            to  keep the source on line,   set  DIR to 40,  leaving  the 
+            first 40 blocks of the file free to hold the  code.   Other-
+            wise,  set DIR to 0 and be careful.
 
-              Thå resô oæ thå disë ió spliô intï twï parts¬  á directorù 
-            areá  anä á datá area®   Iæ eitheò areá getó full¬  thå treå 
-            wilì bå ablå tï accepô nï morå data®  Yoõ shoulä chooså #DIÒ 
-            sucè  thaô botè areaó filì uğ aô abouô thå  samå  rate®  Thå 
-            besô numbeò tï uså iî dependenô oî thå averagå messagå size®  
-            É  woulä suggesô ² oò ³ directorù slotó foò eacè 1ë oæ  datá 
-            area®   Sincå  therå  arå  abouô 2² directorù slotó iî  á  á 
-            block¬  thió  wilì  takå  uğ 10-15¥ oæ  thå  disë  anä  wilì 
-            generallù be enough unless the messages are very short.
+              The rest of the disk is split into two parts,  a directory 
+            area  and a data area.   If either area gets full,  the tree 
+            will be able to accept no more data.  You should choose #DIR 
+            such  that both areas fill up at about the  same  rate.  The 
+            best number to use in dependent on the average message size.  
+            I  would suggest 2 or 3 directory slots for each 1k of  data 
+            area.   Since  there  are  about 22 directory slots in  a  a 
+            block,  this  will  take  up 10-15% of  the  disk  and  will 
+            generally be enough unless the messages are very short.
 
-              Thå constantó #BYTEÓ anä TREÅ arå calculateä automaticallù 
-            durinç compilå anä telì thå £ oæ byteó iî thå datá areá  anä 
-            blocë thaô thaô areá starts.
+              The constants #BYTES and TREE are calculated automatically 
+            during compile and tell the # of bytes in the data area  and 
+            block that that area starts.
              
 
             Data structures
             ---------------
-              Oæ  theså  therå  arå two®   Thå firsô ió  á  fixed-lengtè 
+              Of  these  there  are two.   The first is  a  fixed-length 
             directory record, and the second is the body of the message.
 
-              Eacè messagå iî thå treå ió jusô á simplå ascié file¬ witè 
-            thå lineó endinç iî CRLÆ witè  EOÆ (26h© markinç thå enä  oæ 
-            thå file®   Again¬  therå iî nï reaì restrictioî oî thå sizå 
-            oæ  thå  messagå  otheò  theî  disë  space®    Iæ   yoõ  arå 
-            perceptive¬   yoõ  maù  noticå  thió  ió  exactlù  thå  samå 
-            structurå  aó á cp/í texô file®   Notå thaô yoõ cannoô storå 
-            coí  fileó iî thió structure¬  aó theù maù contaiî EOF'ó  iî 
-            baä places.
-Š
+              Each message in the tree is just a simple ascii file, with 
+            the lines ending in CRLF with  EOF (26h) marking the end  of 
+            the file.   Again,  there in no real restriction on the size 
+            of  the  message  other  then  disk  space.    If   you  are 
+            perceptive,   you  may  notice  this  is  exactly  the  same 
+            structure  as a cp/m text file.   Note that you cannot store 
+            com  files in this structure,  as they may contain EOF's  in 
+            bad places.
+
+
 
 
 
@@ -261,50 +265,51 @@
              Documentation for FBBS-2.0  ** 1/26/85  **  page 5
 
 
-              Thå directorù recorä containó thå namå oæ thå  message¬  á 
-            fe÷ usefuì fieldó sucè aó usage¬ datå anä length¬  á pointeò 
-            tï wherå thå texô oæ thå messagå resides¬  anä ³ pointeró tï 
-            otheò recordó tï forí thå treå structurå (parent¬  daughter¬ 
-            anä sister)®  Notå thaô therå arå pointeró tï records®  Thió 
-            meanó  shufflinç  thå  recordó abouô ió á  reaì  no-no®   Aó 
-            directorù slotó becomå availablå wheî messageó arå  removed¬ 
-            theù  arå  kepô tracë oæ bù á linkeä lisô witè thå  variablå 
+              The directory record contains the name of the  message,  a 
+            few useful fields such as usage, date and length,  a pointer 
+            to where the text of the message resides,  and 3 pointers to 
+            other records to form the tree structure (parent,  daughter, 
+            and sister).  Note that there are pointers to records.  This 
+            means  shuffling  the  records about is a  real  no-no.   As 
+            directory slots become available when messages are  removed, 
+            they  are  kept track of by a linked list with the  variable 
             MT.PTR pointing to the most recently freed slot.
-              Notå  alsï  thaô  thå 3² biô pointeò tï thå  texô  oæ  thå 
-            messagå  ió thå onlù direcô referencå tï thaô  message.  Alì 
-            otheò  referenceó shoulä bå madå thrõ thå  directory®   Thió 
-            allowó  messageó  tï  bå  moveä  wheî  thå  disë  ió   beinç 
+              Note  also  that  the 32 bit pointer to the  text  of  the 
+            message  is the only direct reference to that  message.  All 
+            other  references should be made thru the  directory.   This 
+            allows  messages  to  be  moved  when  the  disk  is   being 
             compacted.
 
 
             Tree Structure
             --------------
-              Iæ  you'vå eveò donå aî INDEØ <msg-name¾ thå structurå  oæ 
-            thå treå ió obvious®   Eacè messagå haó á parent®  Thå firsô 
-            sub-messagå  oæ á messagå ió it'ó daughter®   Tï achivå  thå 
-            effecô  oæ unlimiteä numbeò oæ daughters¬  thå daughteò  caî 
-            poinô  tï á youngeò sister®   Thå youngesô sist4. TUTOR.LBR and HELP.BLK also some documentation files.        5. FBBS Forth based BBS with source.  Two revisions.            6. F83 Text and Documentation files collection.                 7. Library files A-I  (Files used every day are kept on one of) 8. Library files J-P  (the above working disks.  These are)     9. Library files Q-Z  (new to me or I don't have room above.)   Send a SASE for a index list with citations.  Include a letter  or a dollar.  John A. Peters 121 Santa Rosa Ave, SF, CA 94112   :
+              If  you've ever done an INDEX <msg-name> the structure  of 
+            the tree is obvious.   Each message has a parent.  The first 
+            sub-message  of a message is it's daughter.   To achive  the 
+            effect  of unlimited number of daughters,  the daughter  can 
+            point  to a younger sister.   The youngest sist4. TUTOR.LBR and HELP.BLK also some documentation files.        5. FBBS Forth based BBS with source.  Two revisions.            6. F83 Text and Documentation files collection.                 7. Library files A-I  (Files used every day are kept on one of) 8. Library files J-P  (the above working disks.  These are)     9. Library files Q-Z  (new to me or I don't have room above.)   Send a SASE for a index list with citations.  Include a letter  or a dollar.  John A. Peters 121 Santa Rosa Ave, SF, CA 94112   :
 
               1) If there is a daughter, it becomes the new message
 
-              2) Iæ therå ió nï daughter¬ puô therå ió á youngeò sister¬ 
-                 iô  becomeó thå nexô message.
+              2) If there is no daughter, put there is a younger sister, 
+                 it  becomes the next message.
 
-              3) Iæ therå arå neitheò gï uğ thå treå untiì á parenô witè 
-                 á  youngeò sisteò ió found¬  whicè wilì becomå thå nexô 
-                 message®   Iæ nï youngeò sisteò caî bå found¬  returî á 
-                 zerï tï indicatå thaô thå treå ió exhausted.
+              3) If there are neither go up the tree until a parent with 
+                 a  younger sister is found,  which will become the next 
+                 message.   If no younger sister can be found,  return a 
+                 zero to indicate that the tree is exhausted.
 
 
             CRUNCHing the disk
             ------------------
-              Thió  ió  littlå  biô complicated¬  buô stilì  onlù  threå 
-            screenó wortè oæ complicated®  Thå ideá behinä crunchinç thå 
-            disë  ió tï takå alì thå messageó anä rearrangå theí  but-uğ 
-            againsô onå another¬   makinç alì thå emptù spacå contiguouó 
-            anä  readù foò morå messages®   Thió ió donå bù  buildinç  á 
-            lisô  oæ  eacè  oæ thå currentlù  occupieä  directorù  slotó 
-            sorteä  bù  thå addresó oæ thå messagå  (BUILD-LIST)®   Witè Š
+              This  is  little  bit complicated,  but still  only  three 
+            screens worth of complicated.  The idea behind crunching the 
+            disk  is to take all the messages and rearrange them  but-up 
+            against one another,   making all the empty space contiguous 
+            and  ready for more messages.   This is done by  building  a 
+            list  of  each  of the currently  occupied  directory  slots 
+            sorted  by  the address of the message  (BUILD-LIST).   With 
+
 
 
 
@@ -315,67 +320,20 @@
              Documentation for FBBS-2.0  ** 1/26/85  **  page 6
 
 
-            thió list¬   CRUNCÈ caî movå eacè oæ thå messageó tï thå lo÷ 
-            enä  oæ thå file¬  updatinç thå thå addresó pointeró oî  thå 
-            fly®    Afteò  doinç alì this¬  wå updatå END.PTÒ sï wå  caî 
+            this list,   CRUNCH can move each of the messages to the low 
+            end  of the file,  updating the the address pointers on  the 
+            fly.    After  doing all this,  we update END.PTR so we  can 
             make use of the space we freed.
 
             Customization:
             --------------
-              Yoõ maù havå noticeä morå thaî á fe÷ thingó havå beeî lefô 
-            ouô  oæ thå code¬  sucè aó bullet-proofinç anä modeí  inter-
-            face®   É consideò thió sorô oæ thinç tï bå system-dependenô 
-            anä noô reallù alì thaô difficulô tï program®   Thió codå ió 
-            thå  meaô  oæ á bbó (iî á reasonabllù smalì  anä  digestablå 
-            portion)¬ yoõ maù seasoî iô tï youò owî taste.
+              You may have noticed more than a few things have been left 
+            out  of the code,  such as bullet-proofing and modem  inter-
+            face.   I consider this sort of thing to be system-dependent 
+            and not really all that difficult to program.   This code is 
+            the  meat  of a bbs (in a reasonablly small  and  digestable 
+            portion), you may season it to your own taste.
 
-              Iæ yoõ neeä somå hints¬   É havå ideaó (anä á littlå code©  
-            foò  everythinç froí archivaì tï passwordó tï  multi-taskinç 
-            tï user-logons.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+              If you need some hints,   I have ideas (and a little code)  
+            for  everything from archival to passwords to  multi-tasking 
+            to user-logons.


### PR DESCRIPTION
The FBBS2.DOC file has random or parity values in the high bit, rendering it unreadable on modern computers.  This clears the high bit to make it plain ASCII text.